### PR TITLE
IdProvider fixes and equality addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dart_webuntis:
 The basic tool used to interact with the API is the Session object.
 ```dart
 // .init(server, school, username, password, Optional: useragent)
-Session mySession = await Session.init("demo.server.com", "demo_school", "demo_user", "demo_pass")
+Session mySession = await Session.init("demo.server.com", "demo_school", "demo_user", "demo_pass");
 // The ID of the account which credentials you used should now be available over the .userId attribute
 var myId = mySession.userId!;
 // Alternatively you can also search for a student

--- a/lib/untis.dart
+++ b/lib/untis.dart
@@ -499,6 +499,13 @@ class IdProvider {
 
   @override
   String toString() => "IdProvider<type:${type.toString()}, id:$id>";
+
+  bool operator ==(other) {
+    return (other is IdProvider && other.type == type && other.id == id);
+  }
+
+  int get hashCode => hashCode;
+
 }
 
 class _CacheEntry {

--- a/lib/untis.dart
+++ b/lib/untis.dart
@@ -169,7 +169,7 @@ class Session {
   List<Subject> _parseSubjects(List<dynamic> rawSubjects) {
     return List.generate(rawSubjects.length, (index) {
       var subject = rawSubjects[index];
-      return Subject._(IdProvider._internal(IdProviderTypes.STUDENT, subject["id"]), subject["name"],
+      return Subject._(IdProvider._internal(IdProviderTypes.SUBJECT, subject["id"]), subject["name"],
           subject["longName"], subject["alternateName"]);
     });
   }

--- a/lib/untis.dart
+++ b/lib/untis.dart
@@ -146,11 +146,11 @@ class Session {
         List.generate(
             period["kl"].length, (index) => IdProvider._withType(IdProviderTypes.KLASSE, period["kl"][index]["id"])),
         List.generate(
-            period["te"].length, (index) => IdProvider._withType(IdProviderTypes.KLASSE, period["te"][index]["id"])),
+            period["te"].length, (index) => IdProvider._withType(IdProviderTypes.TEACHER, period["te"][index]["id"])),
         List.generate(
-            period["su"].length, (index) => IdProvider._withType(IdProviderTypes.KLASSE, period["su"][index]["id"])),
+            period["su"].length, (index) => IdProvider._withType(IdProviderTypes.SUBJECT, period["su"][index]["id"])),
         List.generate(
-            period["ro"].length, (index) => IdProvider._withType(IdProviderTypes.KLASSE, period["ro"][index]["id"])),
+            period["ro"].length, (index) => IdProvider._withType(IdProviderTypes.ROOM, period["ro"][index]["id"])),
         period["activityType"],
         (period["code"] ?? "") == "cancelled",
         period["code"],


### PR DESCRIPTION
Hi,
I noticed that the subjects had the type STUDENT. This is obviously wrong, so fixed now. After that I noticed this again in the timetable function, so fixed that too. 
I also found it a bit weird, that the same two IdProviders.toStrings e.g. IdProvider<type:IdProviderTypes.SUBJECT, id:16>, didn't match with idProv1 == idProv2. So I thought it would be a nice addition to just include this right out of the box. Then you would not have to compare idProv1.id with idProv2.id.
Anyways,
bye